### PR TITLE
Fix: disallow next_token from being None on re-fetch

### DIFF
--- a/anitopy/parser_number.py
+++ b/anitopy/parser_number.py
@@ -425,7 +425,7 @@ def search_for_equivalent_numbers(tokens):
             continue
         next_token = Tokens.find_next(
             next_token, TokenFlags.ENCLOSED | TokenFlags.NOT_DELIMITER)
-        if next_token.category != TokenCategory.UNKNOWN:
+        if next_token is None or next_token.category != TokenCategory.UNKNOWN:
             continue
 
         # Check if it's an isolated number


### PR DESCRIPTION
In some cases, in the `search_for_equivalent_numbers` function, the `next_token` variable could be `None` even on the re-fetch for the next token. This was breaking parsing in some cases.

Before fix:
```py
>>> import anitopy
>>> anitopy.parse("[Judas] Claymore - 09 - Those Who Rend Asunder (Part 1).mkv")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "anitopy\anitopy.py", line 48, in parse
    if not parser.parse():
  File "anitopy\parser.py", line 21, in parse
    self.search_for_episode_number()
  File "anitopy\parser.py", line 143, in search_for_episode_number
    if parser_number.search_for_equivalent_numbers(tokens):
  File "anitopy\parser_number.py", line 428, in search_for_equivalent_numbers
    if next_token.category != TokenCategory.UNKNOWN:
AttributeError: 'NoneType' object has no attribute 'category'
```

After fix:
```py
>>> import anitopy
>>> anitopy.parse("[Judas] Claymore - 09 - Those Who Rend Asunder (Part 1).mkv")
{'file_name': '[Judas] Claymore - 09 - Those Who Rend Asunder (Part 1).mkv', 'file_extension': 'mkv', 'episode_number': '09', 'anime_title': 'Claymore', 'release_group': 'Judas', 'episode_title': 'Those Who Rend Asunder'}
```

I confirmed this case with the original [anitomy repo](https://github.com/erengy/anitomy), and the output matches my applied fix.