### PR TITLE
Refactor: remove use of singletons

### DIFF
--- a/anitopy/anitopy.py
+++ b/anitopy/anitopy.py
@@ -20,18 +20,18 @@ default_options = {
 
 
 def parse(filename, options=default_options):
-    Elements.clear()
-    Tokens.clear()
+    elements = Elements()
+    tokens = Tokens()
 
     # Add missing options
     for key, value in default_options.items():
         options.setdefault(key, value)
 
-    Elements.insert(ElementCategory.FILE_NAME, filename)
+    elements.insert(ElementCategory.FILE_NAME, filename)
     if options['parse_file_extension']:
         filename, extension = remove_extension_from_filename(filename)
         if extension:
-            Elements.insert(ElementCategory.FILE_EXTENSION, extension)
+            elements.insert(ElementCategory.FILE_EXTENSION, extension)
 
     if options['ignored_strings']:
         filename = remove_ignored_strings_from_filename(
@@ -40,15 +40,15 @@ def parse(filename, options=default_options):
     if not filename:
         return None
 
-    tokenizer = Tokenizer(filename, options)
+    tokenizer = Tokenizer(filename, options, elements, tokens)
     if not tokenizer.tokenize():
         return None
 
-    parser = Parser(options)
+    parser = Parser(options, elements, tokens)
     if not parser.parse():
         return None
 
-    return Elements.get_dictionary()
+    return elements.get_dictionary()
 
 
 def remove_extension_from_filename(filename):

--- a/anitopy/element.py
+++ b/anitopy/element.py
@@ -73,68 +73,46 @@ class ElementCategory(Enum):
 
 
 class Elements:
-    INSTANCE = None
-
     def __init__(self):
         self._elements = {}
         self._check_alt_number = False
 
-    @classmethod
-    def get_check_alt_number(cls):
-        return cls.instance()._check_alt_number
+    def get_check_alt_number(self):
+        return self._check_alt_number
 
-    @classmethod
-    def set_check_alt_number(cls, value):
-        cls.instance()._check_alt_number = value
+    def set_check_alt_number(self, value):
+        self._check_alt_number = value
 
-    @classmethod
-    def instance(cls):
-        if not cls.INSTANCE:
-            cls.INSTANCE = Elements()
-        return cls.INSTANCE
+    def insert(self, category, content):
+        self._elements.setdefault(category.value, []).append(content)
 
-    @classmethod
-    def clear(cls):
-        del cls.INSTANCE
-        cls.INSTANCE = None
-
-    @classmethod
-    def insert(cls, category, content):
-        cls.instance()._elements.setdefault(category.value, []).append(content)
-
-    @classmethod
-    def erase(cls, category):
-        elements = cls.instance()._elements
+    def erase(self, category):
+        elements = self._elements
         if category.value in elements:
             del elements[category.value]
 
-    @classmethod
-    def remove(cls, category, content):
-        elements = cls.instance()._elements
+    def remove(self, category, content):
+        elements = self._elements
         elements[category.value].remove(content)
         if len(elements[category.value]) == 0:
             del elements[category.value]
 
-    @classmethod
-    def contains(cls, category):
-        return bool(category.value in cls.instance()._elements.keys() and
-                    cls.instance()._elements[category.value])
+    def contains(self, category):
+        return bool(category.value in self._elements.keys() and
+                    self._elements[category.value])
 
-    @classmethod
-    def empty(cls):
-        return not bool(cls.instance()._elements)
+    def empty(self):
+        return not bool(self._elements)
 
-    @classmethod
-    def get(cls, category):
-        return cls.instance()._elements.get(
+    def get(self, category):
+        return self._elements.get(
             category.value, '' if ElementCategory.is_singular(category)
             else [])
 
-    @classmethod
-    def get_dictionary(cls):
+    def get_dictionary(self):
         # Convert single element lists to the element itself
         elements = dict([
             (category, value[0]) if len(value) == 1 else (category, value)
-            for category, value in cls.instance()._elements.items()
+            for category, value in self._elements.items()
         ])
         return elements

--- a/anitopy/keyword.py
+++ b/anitopy/keyword.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals, absolute_import
 
 import unicodedata as ud
 
-from anitopy.element import ElementCategory, Elements
+from anitopy.element import ElementCategory
 
 
 class KeywordOption:
@@ -150,7 +150,7 @@ class KeywordManager:
         return keyword
 
     @staticmethod
-    def peek(string):
+    def peek(elements, string):
         entries = [
             (ElementCategory.AUDIO_TERM, ['Dual Audio', 'Multi Audio']),
             (ElementCategory.VIDEO_TERM, ['H264', 'H.264', 'h264', 'h.264']),
@@ -165,7 +165,7 @@ class KeywordManager:
             for keyword in keywords:
                 keyword_begin_pos = string.find(keyword)
                 if keyword_begin_pos != -1:  # Found the keyword in the string
-                    Elements.insert(category, keyword)
+                    elements.insert(category, keyword)
 
                     keyword_end_pos = keyword_begin_pos + len(keyword)
                     preidentified_tokens.append(

--- a/anitopy/parser.py
+++ b/anitopy/parser.py
@@ -3,14 +3,16 @@
 from __future__ import unicode_literals, absolute_import
 
 from anitopy import parser_helper, parser_number
-from anitopy.element import ElementCategory, Elements
+from anitopy.element import ElementCategory
 from anitopy.keyword import keyword_manager
-from anitopy.token import TokenCategory, TokenFlags, Tokens
+from anitopy.token import TokenCategory, TokenFlags
 
 
 class Parser:
-    def __init__(self, options):
+    def __init__(self, options, elements, tokens):
         self.options = options
+        self.elements = elements
+        self.tokens = tokens
 
     def parse(self):
         self.search_for_keywords()
@@ -23,19 +25,19 @@ class Parser:
         self.search_for_anime_title()
 
         if self.options['parse_release_group'] and \
-                not Elements.contains(ElementCategory.RELEASE_GROUP):
+                not self.elements.contains(ElementCategory.RELEASE_GROUP):
             self.search_for_release_group()
 
         if self.options['parse_episode_title'] and \
-                Elements.contains(ElementCategory.EPISODE_NUMBER):
+                self.elements.contains(ElementCategory.EPISODE_NUMBER):
             self.search_for_episode_title()
 
         self.validate_elements()
 
-        return not Elements.empty()
+        return not self.elements.empty()
 
     def search_for_keywords(self):
-        for token in Tokens.get_list(TokenFlags.UNKNOWN):
+        for token in self.tokens.get_list(TokenFlags.UNKNOWN):
             word = token.content
             word = word.strip(' -')
 
@@ -56,40 +58,40 @@ class Parser:
                         not keyword.options.searchable:
                     continue
                 if ElementCategory.is_singular(category) and \
-                        Elements.contains(category):
+                        self.elements.contains(category):
                     continue
 
                 if category == ElementCategory.ANIME_SEASON_PREFIX:
-                    parser_helper.check_anime_season_keyword(token)
+                    parser_helper.check_anime_season_keyword(self.elements, self.tokens, token)
                     continue
                 elif category == ElementCategory.EPISODE_PREFIX:
                     if keyword.options.valid:
                         parser_number.check_extent_keyword(
-                            ElementCategory.EPISODE_NUMBER, token)
+                            self.elements, self.tokens, ElementCategory.EPISODE_NUMBER, token)
                     continue
                 elif category == ElementCategory.RELEASE_VERSION:
                     word = word[1:]  # number without "v"
                 elif category == ElementCategory.VOLUME_PREFIX:
                     parser_number.check_extent_keyword(
-                        ElementCategory.VOLUME_NUMBER, token)
+                        self.elements, self.tokens, ElementCategory.VOLUME_NUMBER, token)
                     continue
             else:
-                if not Elements.contains(ElementCategory.FILE_CHECKSUM) and \
+                if not self.elements.contains(ElementCategory.FILE_CHECKSUM) and \
                         parser_helper.is_crc32(word):
                     category = ElementCategory.FILE_CHECKSUM
-                elif not Elements.contains(ElementCategory.VIDEO_RESOLUTION) \
+                elif not self.elements.contains(ElementCategory.VIDEO_RESOLUTION) \
                         and parser_helper.is_resolution(word):
                     category = ElementCategory.VIDEO_RESOLUTION
 
             if category != ElementCategory.UNKNOWN:
-                Elements.insert(category, word)
+                self.elements.insert(category, word)
                 if keyword is None or keyword.options.identifiable:
                     token.category = TokenCategory.IDENTIFIER
 
     def search_for_isolated_numbers(self):
-        for token in Tokens.get_list(TokenFlags.UNKNOWN):
+        for token in self.tokens.get_list(TokenFlags.UNKNOWN):
             if not token.content.isdigit() or \
-                    not parser_helper.is_token_isolated(token):
+                    not parser_helper.is_token_isolated(self.tokens, token):
                 continue
 
             number = int(token.content)
@@ -97,8 +99,8 @@ class Parser:
             # Anime year
             if number >= parser_number.ANIME_YEAR_MIN and \
                     number <= parser_number.ANIME_YEAR_MAX:
-                if not Elements.contains(ElementCategory.ANIME_YEAR):
-                    Elements.insert(ElementCategory.ANIME_YEAR, token.content)
+                if not self.elements.contains(ElementCategory.ANIME_YEAR):
+                    self.elements.insert(ElementCategory.ANIME_YEAR, token.content)
                     token.category = TokenCategory.IDENTIFIER
                     continue
 
@@ -107,30 +109,30 @@ class Parser:
                 # If these numbers are isolated, it's more likely for them to
                 # be the video resolution rather than the episode number. Some
                 # fansub groups use these without the "p" suffix.
-                if not Elements.contains(ElementCategory.VIDEO_RESOLUTION):
-                    Elements.insert(
+                if not self.elements.contains(ElementCategory.VIDEO_RESOLUTION):
+                    self.elements.insert(
                         ElementCategory.VIDEO_RESOLUTION, token.content)
                     token.category = TokenCategory.IDENTIFIER
                     continue
 
     def search_for_episode_number(self):
         # List all unknown tokens that contain a number
-        tokens = [token for token in Tokens.get_list(TokenFlags.UNKNOWN)
+        tokens = [token for token in self.tokens.get_list(TokenFlags.UNKNOWN)
                   if parser_helper.find_number_in_string(token.content) is not
                   None]
 
         if not tokens:
             return
 
-        Elements.set_check_alt_number(
-            Elements.contains(ElementCategory.EPISODE_NUMBER))
+        self.elements.set_check_alt_number(
+            self.elements.contains(ElementCategory.EPISODE_NUMBER))
 
         # If a token matches a known episode pattern, it has to be the episode
         # number
-        if parser_number.search_for_episode_patterns(tokens):
+        if parser_number.search_for_episode_patterns(self.elements, self.tokens, tokens):
             return
 
-        if Elements.contains(ElementCategory.EPISODE_NUMBER):
+        if self.elements.contains(ElementCategory.EPISODE_NUMBER):
             return  # We have previously found an episode number via keywords
 
         # From now on, we're only interested in numeric tokens
@@ -140,34 +142,34 @@ class Parser:
             return
 
         # e.g. "01 (176)", "29 (04)"
-        if parser_number.search_for_equivalent_numbers(tokens):
+        if parser_number.search_for_equivalent_numbers(self.elements, self.tokens, tokens):
             return
 
         # e.g. " - 08"
-        if parser_number.search_for_separated_numbers(tokens):
+        if parser_number.search_for_separated_numbers(self.elements, self.tokens, tokens):
             return
 
         # e.g. "[12]", "(2006)"
-        if parser_number.search_for_isolated_numbers(tokens):
+        if parser_number.search_for_isolated_numbers(self.elements, self.tokens, tokens):
             return
 
         # Consider using the last number as a last resort
-        parser_number.search_for_last_number(tokens)
+        parser_number.search_for_last_number(self.elements, self.tokens, tokens)
 
     def search_for_anime_title(self):
         enclosed_title = False
 
         # Find the first non-enclosed unknown token
-        token_begin = Tokens.find(TokenFlags.NOT_ENCLOSED | TokenFlags.UNKNOWN)
+        token_begin = self.tokens.find(TokenFlags.NOT_ENCLOSED | TokenFlags.UNKNOWN)
 
         # If that doesn't work, find the first unknown token in the second
         # enclosed group, assuming that the first one is the release group
         if token_begin is None:
             enclosed_title = True
-            token_begin = Tokens.get(0)
+            token_begin = self.tokens.get(0)
             skipped_previous_group = False
             while token_begin is not None:
-                token_begin = Tokens.find_next(token_begin, TokenFlags.UNKNOWN)
+                token_begin = self.tokens.find_next(token_begin, TokenFlags.UNKNOWN)
                 if token_begin is None:
                     break
                 # Ignore groups that are composed of non-Latin characters
@@ -175,7 +177,7 @@ class Parser:
                     if skipped_previous_group:
                         break  # Found it
                 # Get the first unknown token of the next group
-                token_begin = Tokens.find_next(token_begin, TokenFlags.BRACKET)
+                token_begin = self.tokens.find_next(token_begin, TokenFlags.BRACKET)
                 skipped_previous_group = True
 
         if token_begin is None:
@@ -183,7 +185,7 @@ class Parser:
 
         # Continue until an identifier (or a bracket, if the title is enclosed)
         # is found
-        token_end = Tokens.find_next(
+        token_end = self.tokens.find_next(
             token_begin, TokenFlags.IDENTIFIER | (
                 TokenFlags.BRACKET if enclosed_title else TokenFlags.NONE
             ))
@@ -193,8 +195,7 @@ class Parser:
         if not enclosed_title:
             last_bracket = token_end
             bracket_open = False
-            for token in Tokens.get_list(TokenFlags.BRACKET, begin=token_begin,
-                                         end=token_end):
+            for token in self.tokens.get_list(TokenFlags.BRACKET, begin=token_begin, end=token_end):
                 last_bracket = token
                 bracket_open = not bracket_open
             if bracket_open:
@@ -205,19 +206,19 @@ class Parser:
         # group. We ignore parentheses in order to keep certain groups (e.g.
         # "(TV)") intact.
         if not enclosed_title:
-            token = Tokens.find_previous(token_end, TokenFlags.NOT_DELIMITER)
+            token = self.tokens.find_previous(token_end, TokenFlags.NOT_DELIMITER)
             while token.category == TokenCategory.BRACKET and \
                     token.content != ')':
-                token = Tokens.find_previous(token, TokenFlags.BRACKET)
+                token = self.tokens.find_previous(token, TokenFlags.BRACKET)
                 if token is not None:
                     token_end = token
-                    token = Tokens.find_previous(
+                    token = self.tokens.find_previous(
                         token_end, TokenFlags.NOT_DELIMITER)
 
         # Token end is a bracket, so we get the previous token to be included
         # in the element
-        token_end = Tokens.find_previous(token_end, TokenFlags.VALID)
-        parser_helper.build_element(ElementCategory.ANIME_TITLE, token_begin,
+        token_end = self.tokens.find_previous(token_end, TokenFlags.VALID)
+        parser_helper.build_element(self.elements, self.tokens, ElementCategory.ANIME_TITLE, token_begin,
                                     token_end, keep_delimiters=False)
 
     def search_for_release_group(self):
@@ -225,16 +226,16 @@ class Parser:
         while True:
             # Find the first enclosed unknown token
             if token_end:
-                token_begin = Tokens.find_next(
+                token_begin = self.tokens.find_next(
                     token_end, TokenFlags.ENCLOSED | TokenFlags.UNKNOWN)
             else:
-                token_begin = Tokens.find(
+                token_begin = self.tokens.find(
                     TokenFlags.ENCLOSED | TokenFlags.UNKNOWN)
             if token_begin is None:
                 return
 
             # Continue until a bracket or identifier is found
-            token_end = Tokens.find_next(
+            token_end = self.tokens.find_next(
                 token_begin, TokenFlags.BRACKET | TokenFlags.IDENTIFIER)
             if token_end is None:
                 return
@@ -242,7 +243,7 @@ class Parser:
                 continue
 
             # Ignore if it's not the first non-delimiter token in group
-            previous_token = Tokens.find_previous(
+            previous_token = self.tokens.find_previous(
                 token_begin, TokenFlags.NOT_DELIMITER)
             if previous_token is not None and \
                     previous_token.category != TokenCategory.BRACKET:
@@ -250,8 +251,9 @@ class Parser:
 
             # Build release group, token end is a bracket, so we get the
             # previous token to be included in the element
-            token_end = Tokens.find_previous(token_end, TokenFlags.VALID)
+            token_end = self.tokens.find_previous(token_end, TokenFlags.VALID)
             parser_helper.build_element(
+                self.elements, self.tokens,
                 ElementCategory.RELEASE_GROUP, token_begin, token_end,
                 keep_delimiters=True)
             return
@@ -261,48 +263,49 @@ class Parser:
         while True:
             # Find the first non-enclosed unknown token
             if token_end:
-                token_begin = Tokens.find_next(
+                token_begin = self.tokens.find_next(
                     token_end, TokenFlags.NOT_ENCLOSED | TokenFlags.UNKNOWN)
             else:
-                token_begin = Tokens.find(
+                token_begin = self.tokens.find(
                     TokenFlags.NOT_ENCLOSED | TokenFlags.UNKNOWN)
             if token_begin is None:
                 return
 
             # Continue until a bracket or identifier is found
-            token_end = Tokens.find_next(
+            token_end = self.tokens.find_next(
                 token_begin, TokenFlags.BRACKET | TokenFlags.IDENTIFIER)
 
             # Ignore if it's only a dash
-            if Tokens.distance(token_begin, token_end) <= 2 and \
+            if self.tokens.distance(token_begin, token_end) <= 2 and \
                     parser_helper.is_dash_character(token_begin.content):
                 continue
 
             # If token end is a bracket, then we get the previous token to be
             # included in the element
             if token_end and token_end.category == TokenCategory.BRACKET:
-                token_end = Tokens.find_previous(token_end, TokenFlags.VALID)
+                token_end = self.tokens.find_previous(token_end, TokenFlags.VALID)
             # Build episode title
             parser_helper.build_element(
+                self.elements, self.tokens,
                 ElementCategory.EPISODE_TITLE, token_begin, token_end,
                 keep_delimiters=False)
             return
 
     def validate_elements(self):
         # Validate anime type and episode title
-        if Elements.contains(ElementCategory.ANIME_TYPE) and \
-                Elements.contains(ElementCategory.EPISODE_TITLE):
+        if self.elements.contains(ElementCategory.ANIME_TYPE) and \
+                self.elements.contains(ElementCategory.EPISODE_TITLE):
             # Here we check whether the episode title contains an anime type
-            episode_title = Elements.get(ElementCategory.EPISODE_TITLE)[0]
+            episode_title = self.elements.get(ElementCategory.EPISODE_TITLE)[0]
             # Copy list because we may modify it
-            anime_type_list = list(Elements.get(ElementCategory.ANIME_TYPE))
+            anime_type_list = list(self.elements.get(ElementCategory.ANIME_TYPE))
             for anime_type in anime_type_list:
                 if anime_type == episode_title:
                     # Invalid episode title
-                    Elements.erase(ElementCategory.EPISODE_TITLE)
+                    self.elements.erase(ElementCategory.EPISODE_TITLE)
                 elif anime_type in episode_title:
                     norm_anime_type = keyword_manager.normalize(anime_type)
                     if keyword_manager.find(
                             norm_anime_type, ElementCategory.ANIME_TYPE):
-                        Elements.remove(ElementCategory.ANIME_TYPE, anime_type)
+                        self.elements.remove(ElementCategory.ANIME_TYPE, anime_type)
                         continue

--- a/anitopy/parser_helper.py
+++ b/anitopy/parser_helper.py
@@ -5,8 +5,8 @@ from __future__ import unicode_literals, absolute_import
 import re
 import unicodedata as ud
 
-from anitopy.element import ElementCategory, Elements
-from anitopy.token import TokenCategory, TokenFlags, Tokens
+from anitopy.element import ElementCategory
+from anitopy.token import TokenCategory, TokenFlags
 
 DASHES = '-\u2010\u2011\u2012\u2013\u2014\u2015'
 
@@ -71,20 +71,20 @@ def is_resolution(string):
     return bool(re.match(pattern, string))
 
 
-def check_anime_season_keyword(token):
+def check_anime_season_keyword(elements, parsed_tokens, token):
     def set_anime_season(first, second, content):
-        Elements.insert(ElementCategory.ANIME_SEASON, content)
+        elements.insert(ElementCategory.ANIME_SEASON, content)
         first.category = TokenCategory.IDENTIFIER
         second.category = TokenCategory.IDENTIFIER
 
-    previous_token = Tokens.find_previous(token, TokenFlags.NOT_DELIMITER)
+    previous_token = parsed_tokens.find_previous(token, TokenFlags.NOT_DELIMITER)
     if previous_token:
         number = get_number_from_ordinal(previous_token.content)
         if number:
             set_anime_season(previous_token, token, number)
             return True
 
-    next_token = Tokens.find_next(token, TokenFlags.NOT_DELIMITER)
+    next_token = parsed_tokens.find_next(token, TokenFlags.NOT_DELIMITER)
     if next_token and next_token.content.isdigit():
         set_anime_season(token, next_token, next_token.content)
         return True
@@ -92,12 +92,12 @@ def check_anime_season_keyword(token):
     return False
 
 
-def is_token_isolated(token):
-    previous_token = Tokens.find_previous(token, TokenFlags.NOT_DELIMITER)
+def is_token_isolated(parsed_tokens, token):
+    previous_token = parsed_tokens.find_previous(token, TokenFlags.NOT_DELIMITER)
     if previous_token.category != TokenCategory.BRACKET:
         return False
 
-    next_token = Tokens.find_next(token, TokenFlags.NOT_DELIMITER)
+    next_token = parsed_tokens.find_next(token, TokenFlags.NOT_DELIMITER)
     if next_token.category != TokenCategory.BRACKET:
         return False
 
@@ -106,11 +106,11 @@ def is_token_isolated(token):
 ###############################################################################
 
 
-def build_element(category, token_begin=None, token_end=None,
+def build_element(elements, parsed_tokens, category, token_begin=None, token_end=None,
                   keep_delimiters=False):
     element = ''
 
-    for token in Tokens.get_list(begin=token_begin, end=token_end):
+    for token in parsed_tokens.get_list(begin=token_begin, end=token_end):
         if token.category == TokenCategory.UNKNOWN:
             element += token.content
             token.category = TokenCategory.IDENTIFIER
@@ -130,4 +130,4 @@ def build_element(category, token_begin=None, token_end=None,
         element = element.strip(' ' + DASHES)
 
     if element:
-        Elements.insert(category, element)
+        elements.insert(category, element)

--- a/anitopy/parser_number.py
+++ b/anitopy/parser_number.py
@@ -5,9 +5,9 @@ from __future__ import unicode_literals, absolute_import
 import re
 
 from anitopy import parser_helper
-from anitopy.element import ElementCategory, Elements
+from anitopy.element import ElementCategory
 from anitopy.keyword import keyword_manager
-from anitopy.token import TokenCategory, TokenFlags, Token, Tokens
+from anitopy.token import TokenCategory, TokenFlags, Token
 
 ANIME_YEAR_MIN = 1900
 ANIME_YEAR_MAX = 2050
@@ -26,7 +26,7 @@ def is_valid_episode_number(number):
     return str2int(number) <= EPISODE_NUMBER_MAX
 
 
-def set_episode_number(number, token, validate):
+def set_episode_number(elements, number, token, validate):
     if validate and not is_valid_episode_number(number):
         return False
 
@@ -35,30 +35,30 @@ def set_episode_number(number, token, validate):
     category = ElementCategory.EPISODE_NUMBER
 
     # Handle equivalent numbers
-    if Elements.get_check_alt_number():
+    if elements.get_check_alt_number():
         # TODO: check if getting only the first episode number is enough
-        episode_number = Elements.get(ElementCategory.EPISODE_NUMBER)[0]
+        episode_number = elements.get(ElementCategory.EPISODE_NUMBER)[0]
         if str2int(number) > str2int(episode_number):
             category = ElementCategory.EPISODE_NUMBER_ALT
         elif str2int(number) < str2int(episode_number):
-            Elements.remove(ElementCategory.EPISODE_NUMBER, episode_number)
-            Elements.insert(ElementCategory.EPISODE_NUMBER_ALT, episode_number)
+            elements.remove(ElementCategory.EPISODE_NUMBER, episode_number)
+            elements.insert(ElementCategory.EPISODE_NUMBER_ALT, episode_number)
         else:
             return False
 
-    Elements.insert(category, number)
+    elements.insert(category, number)
     return True
 
 
-def set_alternative_episode_number(number, token):
-    Elements.insert(ElementCategory.EPISODE_NUMBER_ALT, number)
+def set_alternative_episode_number(elements, number, token):
+    elements.insert(ElementCategory.EPISODE_NUMBER_ALT, number)
     token.category = TokenCategory.IDENTIFIER
 
     return True
 
 
-def check_extent_keyword(category, token):
-    next_token = Tokens.find_next(token, TokenFlags.NOT_DELIMITER)
+def check_extent_keyword(elements, parsed_tokens, category, token):
+    next_token = parsed_tokens.find_next(token, TokenFlags.NOT_DELIMITER)
 
     if next_token.category == TokenCategory.UNKNOWN:
         if next_token and \
@@ -66,14 +66,14 @@ def check_extent_keyword(category, token):
                 is not None:
             if category == ElementCategory.EPISODE_NUMBER:
                 if not match_episode_patterns(
-                        next_token.content, next_token):
+                        elements, parsed_tokens, next_token.content, next_token):
                     set_episode_number(
-                        next_token.content, next_token, validate=False)
+                        elements, next_token.content, next_token, validate=False)
             elif category == ElementCategory.VOLUME_NUMBER:
                 if not match_volume_patterns(
-                        next_token.content, next_token):
+                        elements, next_token.content, next_token):
                     set_volume_number(
-                        next_token.content, next_token, validate=False)
+                        elements, next_token.content, next_token, validate=False)
             else:
                 return False
             token.category = TokenCategory.IDENTIFIER
@@ -84,7 +84,7 @@ def check_extent_keyword(category, token):
 ###############################################################################
 
 
-def number_comes_after_prefix(category, token):
+def number_comes_after_prefix(elements, parsed_tokens, category, token):
     number_begin = parser_helper.find_number_in_string(token.content)
     prefix = token.content[:number_begin]
 
@@ -92,32 +92,32 @@ def number_comes_after_prefix(category, token):
     if keyword:
         number = token.content[number_begin:]
         if category == ElementCategory.EPISODE_PREFIX:
-            if match_episode_patterns(number, token):
+            if match_episode_patterns(elements, parsed_tokens, number, token):
                 return True
-            return set_episode_number(number, token, validate=False)
+            return set_episode_number(elements, number, token, validate=False)
         if category == ElementCategory.VOLUME_PREFIX:
-            if match_volume_patterns(number, token):
+            if match_volume_patterns(elements, number, token):
                 return True
-            return set_volume_number(number, token, validate=False)
+            return set_volume_number(elements, number, token, validate=False)
         if category == ElementCategory.ANIME_SEASON_PREFIX:
-            return set_season_number(number, token)
+            return set_season_number(elements, number, token)
 
     return False
 
 
-def number_comes_before_another_number(token):
-    separator_token = Tokens.find_next(token, TokenFlags.NOT_DELIMITER)
+def number_comes_before_another_number(elements, parsed_tokens, token):
+    separator_token = parsed_tokens.find_next(token, TokenFlags.NOT_DELIMITER)
 
     if separator_token:
         separator = separator_token.content
         if separator == '&' or separator == 'of':
-            other_token = Tokens.find_next(
+            other_token = parsed_tokens.find_next(
                 separator_token, TokenFlags.NOT_DELIMITER)
             if other_token and other_token.content.isdigit():
-                set_episode_number(token.content, token, validate=False)
+                set_episode_number(elements, token.content, token, validate=False)
                 if separator == '&':
                     set_episode_number(
-                        other_token.content, token, validate=False)
+                        elements, other_token.content, token, validate=False)
                 separator_token.category = TokenCategory.IDENTIFIER
                 other_token.category = TokenCategory.IDENTIFIER
                 return True
@@ -125,27 +125,27 @@ def number_comes_before_another_number(token):
     return False
 
 
-def search_for_episode_patterns(tokens):
+def search_for_episode_patterns(elements, parsed_tokens, tokens):
     for token in tokens:
         numeric_front = token.content[0].isdigit()
 
         if not numeric_front:
             # e.g. "EP.1", "Vol.1"
             if number_comes_after_prefix(
-                    ElementCategory.EPISODE_PREFIX, token):
+                    elements, parsed_tokens, ElementCategory.EPISODE_PREFIX, token):
                 return True
             if number_comes_after_prefix(
-                    ElementCategory.VOLUME_PREFIX, token):
+                    elements, parsed_tokens, ElementCategory.VOLUME_PREFIX, token):
                 continue
             if number_comes_after_prefix(
-                    ElementCategory.ANIME_SEASON_PREFIX, token):
+                    elements, parsed_tokens, ElementCategory.ANIME_SEASON_PREFIX, token):
                 continue
         else:
             # e.g. "8 & 10", "01 of 24"
-            if number_comes_before_another_number(token):
+            if number_comes_before_another_number(elements, parsed_tokens, token):
                 return True
         # Look for other patterns
-        if match_episode_patterns(token.content, token):
+        if match_episode_patterns(elements, parsed_tokens, token.content, token):
             return True
 
     return False
@@ -153,18 +153,18 @@ def search_for_episode_patterns(tokens):
 ###############################################################################
 
 
-def match_single_episode_pattern(word, token):
+def match_single_episode_pattern(elements, word, token):
     pattern = '(\\d{1,4})[vV](\\d)$'
     match = re.match(pattern, word)
     if match:
-        set_episode_number(match.group(1), token, validate=False)
-        Elements.insert(ElementCategory.RELEASE_VERSION, match.group(2))
+        set_episode_number(elements, match.group(1), token, validate=False)
+        elements.insert(ElementCategory.RELEASE_VERSION, match.group(2))
         return True
 
     return False
 
 
-def match_multi_episode_pattern(word, token):
+def match_multi_episode_pattern(elements, word, token):
     pattern = '(\\d{1,4})(?:[vV](\\d))?[-~&+](\\d{1,4})(?:[vV](\\d))?$'
     match = re.match(pattern, word)
     if match:
@@ -172,20 +172,20 @@ def match_multi_episode_pattern(word, token):
         upper_bound = match.group(3)
         # Avoid matching expressions such as "009-1" or "5-2"
         if int(lower_bound) < int(upper_bound):
-            if set_episode_number(lower_bound, token, validate=True):
-                set_episode_number(upper_bound, token, validate=False)
+            if set_episode_number(elements, lower_bound, token, validate=True):
+                set_episode_number(elements, upper_bound, token, validate=False)
                 if match.group(2):
-                    Elements.insert(
+                    elements.insert(
                         ElementCategory.RELEASE_VERSION, match.group(2))
                 if match.group(4):
-                    Elements.insert(
+                    elements.insert(
                         ElementCategory.RELEASE_VERSION, match.group(4))
                 return True
 
     return False
 
 
-def match_season_and_episode_pattern(word, token):
+def match_season_and_episode_pattern(elements, word, token):
     pattern = 'S?(\\d{1,2})(?:-S?(\\d{1,2}))?' +\
               '(?:x|[ ._-x]?E)(\\d{1,4})(?:-E?(\\d{1,4}))?' +\
               '(?:[vV](\\d))?$'
@@ -194,20 +194,20 @@ def match_season_and_episode_pattern(word, token):
     if match:
         if int(match.group(1)) == 0:
             return False
-        Elements.insert(ElementCategory.ANIME_SEASON, match.group(1))
+        elements.insert(ElementCategory.ANIME_SEASON, match.group(1))
         if match.group(2):
-            Elements.insert(ElementCategory.ANIME_SEASON, match.group(2))
-        set_episode_number(match.group(3), token, validate=False)
+            elements.insert(ElementCategory.ANIME_SEASON, match.group(2))
+        set_episode_number(elements, match.group(3), token, validate=False)
         if match.group(4):
-            set_episode_number(match.group(4), token, validate=False)
+            set_episode_number(elements, match.group(4), token, validate=False)
         if match.group(5):
-            Elements.insert(ElementCategory.RELEASE_VERSION, match.group(5))
+            elements.insert(ElementCategory.RELEASE_VERSION, match.group(5))
         return True
 
     return False
 
 
-def match_type_and_episode_pattern(word, token):
+def match_type_and_episode_pattern(elements, parsed_tokens, word, token):
     number_begin = parser_helper.find_number_in_string(word)
     prefix = word[:number_begin]
 
@@ -215,15 +215,15 @@ def match_type_and_episode_pattern(word, token):
         keyword_manager.normalize(prefix), ElementCategory.ANIME_TYPE)
 
     if keyword:
-        Elements.insert(ElementCategory.ANIME_TYPE, prefix)
+        elements.insert(ElementCategory.ANIME_TYPE, prefix)
         number = word[number_begin:]
-        if match_episode_patterns(number, token) or \
-                set_episode_number(number, token, validate=True):
+        if match_episode_patterns(elements, parsed_tokens, number, token) or \
+                set_episode_number(elements, number, token, validate=True):
             # Split token (we do this last in order to avoid invalidating our
             # token reference earlier)
-            token_index = Tokens.get_index(token)
+            token_index = parsed_tokens.get_index(token)
             token.content = number
-            Tokens.insert(token_index, Token(
+            parsed_tokens.insert(token_index, Token(
                 TokenCategory.IDENTIFIER if keyword.options.identifiable
                 else TokenCategory.UNKNOWN,
                 prefix, token.enclosed))
@@ -232,20 +232,20 @@ def match_type_and_episode_pattern(word, token):
     return False
 
 
-def match_fractional_episode_pattern(word, token):
+def match_fractional_episode_pattern(elements, word, token):
     # We don't allow any fractional part other than ".5", because there are
     # cases where such a number is a part of the anime title (e.g. "Evangelion:
     # 1.11", "Tokyo Magnitude 8.0") or a keyword (e.g. "5.1").
     pattern = '\\d+\\.5$'
     match = re.match(pattern, word)
     if match:
-        if set_episode_number(word, token, validate=True):
+        if set_episode_number(elements, word, token, validate=True):
             return True
 
     return False
 
 
-def match_partial_episode_pattern(word, token):
+def match_partial_episode_pattern(elements, word, token):
     non_number_begin = parser_helper.find_non_number_in_string(word)
     suffix = word[non_number_begin:]
 
@@ -253,13 +253,13 @@ def match_partial_episode_pattern(word, token):
         return len(s) == 1 and s in 'ABCabc'
 
     if is_valid_suffix(suffix):
-        if set_episode_number(word, token, validate=True):
+        if set_episode_number(elements, word, token, validate=True):
             return True
 
     return False
 
 
-def match_number_sign_pattern(word, token):
+def match_number_sign_pattern(elements, word, token):
     if word[0] != '#':
         return False
 
@@ -267,18 +267,18 @@ def match_number_sign_pattern(word, token):
     match = re.match(pattern, word)
 
     if match:
-        if set_episode_number(match.group(1), token, validate=True):
+        if set_episode_number(elements, match.group(1), token, validate=True):
             if match.group(2):
-                set_episode_number(match.group(2), token, validate=True)
+                set_episode_number(elements, match.group(2), token, validate=True)
             if match.group(3):
-                Elements.insert(ElementCategory.RELEASE_VERSION,
+                elements.insert(ElementCategory.RELEASE_VERSION,
                                 match.group(3))
             return True
 
     return False
 
 
-def match_japanese_counter_pattern(word, token):
+def match_japanese_counter_pattern(elements, word, token):
     if word[-1] != '\u8A71':
         return False
 
@@ -286,13 +286,13 @@ def match_japanese_counter_pattern(word, token):
     match = re.match(pattern, word)
 
     if match:
-        if set_episode_number(match.group(1), token, validate=False):
+        if set_episode_number(elements, match.group(1), token, validate=False):
             return True
 
     return False
 
 
-def match_episode_patterns(word, token):
+def match_episode_patterns(elements, parsed_tokens, word, token):
     if word.isdigit():
         return False
 
@@ -303,35 +303,35 @@ def match_episode_patterns(word, token):
 
     # e.g. "01v2"
     if numeric_front and numeric_back:
-        if match_single_episode_pattern(word, token):
+        if match_single_episode_pattern(elements, word, token):
             return True
     # e.g. "01-02", "03-05v2"
     if numeric_front and numeric_back:
-        if match_multi_episode_pattern(word, token):
+        if match_multi_episode_pattern(elements, word, token):
             return True
     # e.g. "2x01", "S01E03", "S01-02xE001-150", "S01E06v2"
     if numeric_back:
-        if match_season_and_episode_pattern(word, token):
+        if match_season_and_episode_pattern(elements, word, token):
             return True
     # e.g. "ED1", "OP4a", "OVA2"
     if not numeric_front:
-        if match_type_and_episode_pattern(word, token):
+        if match_type_and_episode_pattern(elements, parsed_tokens, word, token):
             return True
     # e.g. "07.5"
     if numeric_front and numeric_back:
-        if match_fractional_episode_pattern(word, token):
+        if match_fractional_episode_pattern(elements, word, token):
             return True
     # e.g. "4a", "111C"
     if numeric_front and not numeric_back:
-        if match_partial_episode_pattern(word, token):
+        if match_partial_episode_pattern(elements, word, token):
             return True
     # e.g. "#01", "#02-03v2"
     if numeric_back:
-        if match_number_sign_pattern(word, token):
+        if match_number_sign_pattern(elements, word, token):
             return True
     # U+8A71 is used as counter for stories, episodes of TV series, etc.
     if numeric_front:
-        if match_japanese_counter_pattern(word, token):
+        if match_japanese_counter_pattern(elements, word, token):
             return True
 
     return False
@@ -343,29 +343,29 @@ def is_valid_volume_number(number):
     return int(number) <= VOLUME_NUMBER_MAX
 
 
-def set_volume_number(number, token, validate):
+def set_volume_number(elements, number, token, validate):
     if validate:
         if not is_valid_volume_number(number):
             return False
 
-    Elements.insert(ElementCategory.VOLUME_NUMBER, number)
+    elements.insert(ElementCategory.VOLUME_NUMBER, number)
     token.category = TokenCategory.IDENTIFIER
     return True
 
 
-def match_single_volume_pattern(word, token):
+def match_single_volume_pattern(elements, word, token):
     pattern = '(\\d{1,2})[vV](\\d)$'
     match = re.match(pattern, word)
 
     if match:
-        set_volume_number(match.group(1), token, validate=False)
-        Elements.insert(ElementCategory.RELEASE_VERSION, match.group(2))
+        set_volume_number(elements, match.group(1), token, validate=False)
+        elements.insert(ElementCategory.RELEASE_VERSION, match.group(2))
         return True
 
     return False
 
 
-def match_multi_volume_pattern(word, token):
+def match_multi_volume_pattern(elements, word, token):
     pattern = '(\\d{1,2})[-~&+](\\d{1,2})(?:[vV](\\d))?$'
     match = re.match(pattern, word)
 
@@ -373,17 +373,17 @@ def match_multi_volume_pattern(word, token):
         lower_bound = match.group(1)
         upper_bound = match.group(2)
         if int(lower_bound) < int(upper_bound):
-            if set_volume_number(lower_bound, token, validate=True):
-                set_volume_number(upper_bound, token, validate=False)
+            if set_volume_number(elements, lower_bound, token, validate=True):
+                set_volume_number(elements, upper_bound, token, validate=False)
                 if match.group(3):
-                    Elements.insert(ElementCategory.RELEASE_VERSION,
+                    elements.insert(ElementCategory.RELEASE_VERSION,
                                     match.group(3))
                 return True
 
     return False
 
 
-def match_volume_patterns(word, token):
+def match_volume_patterns(elements, word, token):
     # All patterns contain at least one non-numeric character
     if word.isdigit():
         return False
@@ -395,11 +395,11 @@ def match_volume_patterns(word, token):
 
     # e.g. "01v2"
     if numeric_front and numeric_back:
-        if match_single_volume_pattern(word, token):
+        if match_single_volume_pattern(elements, word, token):
             return True
     # e.g. "01-02", "03-05v2"
     if numeric_front and numeric_back:
-        if match_multi_volume_pattern(word, token):
+        if match_multi_volume_pattern(elements, word, token):
             return True
 
     return False
@@ -407,34 +407,34 @@ def match_volume_patterns(word, token):
 ###############################################################################
 
 
-def set_season_number(number, token):
+def set_season_number(elements, number, token):
     if not number.isdigit():
         return False
 
-    Elements.insert(ElementCategory.ANIME_SEASON, number)
+    elements.insert(ElementCategory.ANIME_SEASON, number)
     token.category = TokenCategory.IDENTIFIER
     return True
 
 ###############################################################################
 
 
-def search_for_equivalent_numbers(tokens):
+def search_for_equivalent_numbers(elements, parsed_tokens, tokens):
     for token in tokens:
-        if parser_helper.is_token_isolated(token) or \
+        if parser_helper.is_token_isolated(parsed_tokens, token) or \
                 not is_valid_episode_number(token.content):
             continue
 
         # Find the first enclosed, non-delimiter token
-        next_token = Tokens.find_next(token, TokenFlags.NOT_DELIMITER)
+        next_token = parsed_tokens.find_next(token, TokenFlags.NOT_DELIMITER)
         if next_token is None or next_token.category != TokenCategory.BRACKET:
             continue
-        next_token = Tokens.find_next(
+        next_token = parsed_tokens.find_next(
             next_token, TokenFlags.ENCLOSED | TokenFlags.NOT_DELIMITER)
         if next_token is None or next_token.category != TokenCategory.UNKNOWN:
             continue
 
         # Check if it's an isolated number
-        if not parser_helper.is_token_isolated(next_token) or \
+        if not parser_helper.is_token_isolated(parsed_tokens, next_token) or \
                 not next_token.content.isdigit() or \
                 not is_valid_episode_number(next_token.content):
             continue
@@ -442,42 +442,42 @@ def search_for_equivalent_numbers(tokens):
         episode = min(token, next_token, key=lambda t: int(t.content))
         alt_episode = max(token, next_token, key=lambda t: int(t.content))
 
-        set_episode_number(episode.content, episode, validate=False)
-        set_alternative_episode_number(alt_episode.content, alt_episode)
+        set_episode_number(elements, episode.content, episode, validate=False)
+        set_alternative_episode_number(elements, alt_episode.content, alt_episode)
 
         return True
 
     return False
 
 
-def search_for_separated_numbers(tokens):
+def search_for_separated_numbers(elements, parsed_tokens, tokens):
     for token in tokens:
-        previous_token = Tokens.find_previous(token, TokenFlags.NOT_DELIMITER)
+        previous_token = parsed_tokens.find_previous(token, TokenFlags.NOT_DELIMITER)
 
         # See if the number has a preceding "-" separator
         if previous_token.category == TokenCategory.UNKNOWN and \
                 parser_helper.is_dash_character(previous_token.content):
-            if set_episode_number(token.content, token, validate=True):
+            if set_episode_number(elements, token.content, token, validate=True):
                 previous_token.category = TokenCategory.IDENTIFIER
                 return True
 
     return False
 
 
-def search_for_isolated_numbers(tokens):
+def search_for_isolated_numbers(elements, parsed_tokens, tokens):
     for token in tokens:
-        if not token.enclosed or not parser_helper.is_token_isolated(token):
+        if not token.enclosed or not parser_helper.is_token_isolated(parsed_tokens, token):
             continue
 
-        if set_episode_number(token.content, token, validate=True):
+        if set_episode_number(elements, token.content, token, validate=True):
             return True
 
     return False
 
 
-def search_for_last_number(tokens):
+def search_for_last_number(elements, parsed_tokens, tokens):
     for token in tokens:
-        token_index = Tokens.get_index(token)
+        token_index = parsed_tokens.get_index(token)
 
         # Assuming that episode number always comes after the title, first
         # token cannot be what we're looking for
@@ -490,18 +490,18 @@ def search_for_last_number(tokens):
 
         # Ignore if it's the first non-enclosed, non-delimiter token
         if all([t.enclosed or t.category == TokenCategory.DELIMITER
-                for t in Tokens.get_list()[:token_index]]):
+                for t in parsed_tokens.get_list()[:token_index]]):
             continue
 
         # Ignore if the previous token is "Movie" or "Part"
-        previous_token = Tokens.find_previous(token, TokenFlags.NOT_DELIMITER)
+        previous_token = parsed_tokens.find_previous(token, TokenFlags.NOT_DELIMITER)
         if previous_token.category == TokenCategory.UNKNOWN:
             if previous_token.content.lower() == 'movie' or \
                     previous_token.content.lower() == 'part':
                 continue
 
         # We'll use this number after all
-        if set_episode_number(token.content, token, validate=True):
+        if set_episode_number(elements, token.content, token, validate=True):
             return True
 
     return False

--- a/anitopy/token.py
+++ b/anitopy/token.py
@@ -93,62 +93,41 @@ class Token:
 
 
 class Tokens:
-    INSTANCE = None
-
     def __init__(self):
         self._tokens = []
 
-    @classmethod
-    def instance(cls):
-        if not cls.INSTANCE:
-            cls.INSTANCE = Tokens()
-        return cls.INSTANCE
+    def empty(self):
+        return len(self._tokens) == 0
 
-    @classmethod
-    def clear(cls):
-        del cls.INSTANCE
-        cls.INSTANCE = None
+    def append(self, token):
+        self._tokens.append(token)
 
-    @classmethod
-    def empty(cls):
-        return len(cls.instance()._tokens) == 0
+    def insert(self, index, token):
+        self._tokens.insert(index, token)
 
-    @classmethod
-    def append(cls, token):
-        cls.instance()._tokens.append(token)
+    def update(self, tokens):
+        self._tokens = tokens
 
-    @classmethod
-    def insert(cls, index, token):
-        cls.instance()._tokens.insert(index, token)
+    def get(self, index):
+        return self._tokens[index]
 
-    @classmethod
-    def update(cls, tokens):
-        cls.instance()._tokens = tokens
-
-    @classmethod
-    def get(cls, index):
-        return cls.instance()._tokens[index]
-
-    @classmethod
-    def get_list(cls, flags=None, begin=None, end=None):
-        tokens = cls.instance()._tokens
-        begin_index = 0 if begin is None else cls.get_index(begin)
-        end_index = len(tokens) if end is None else cls.get_index(end)
+    def get_list(self, flags=None, begin=None, end=None):
+        tokens = self._tokens
+        begin_index = 0 if begin is None else self.get_index(begin)
+        end_index = len(tokens) if end is None else self.get_index(end)
         if flags is None:
             return tokens[begin_index:end_index+1]
         else:
             return [token for token in tokens[begin_index:end_index+1]
                     if token.check_flags(flags)]
 
-    @classmethod
-    def get_index(cls, token):
-        return cls.instance()._tokens.index(token)
+    def get_index(self, token):
+        return self._tokens.index(token)
 
-    @classmethod
-    def distance(cls, token_begin, token_end):
-        begin_index = 0 if token_begin is None else cls.get_index(token_begin)
-        end_index = len(cls.instance()._tokens) if token_end is None else \
-            cls.get_index(token_end)
+    def distance(self, token_begin, token_end):
+        begin_index = 0 if token_begin is None else self.get_index(token_begin)
+        end_index = len(self._tokens) if token_end is None else \
+            self.get_index(token_end)
         return end_index - begin_index
 
     @staticmethod
@@ -158,24 +137,21 @@ class Tokens:
                 return token
         return None
 
-    @classmethod
-    def find(cls, flags):
-        return cls._find_in_tokens(cls.instance()._tokens, flags)
+    def find(self, flags):
+        return self._find_in_tokens(self._tokens, flags)
 
-    @classmethod
-    def find_previous(cls, token, flags):
-        tokens = cls.instance()._tokens
+    def find_previous(self, token, flags):
+        tokens = self._tokens
         if token is None:
             tokens = tokens[::-1]
         else:
-            token_index = cls.get_index(token)
+            token_index = self.get_index(token)
             tokens = tokens[token_index-1::-1]
-        return cls._find_in_tokens(tokens, flags)
+        return self._find_in_tokens(tokens, flags)
 
-    @classmethod
-    def find_next(cls, token, flags):
-        tokens = cls.instance()._tokens
+    def find_next(self, token, flags):
+        tokens = self._tokens
         if token is not None:
-            token_index = cls.get_index(token)
+            token_index = self.get_index(token)
             tokens = tokens[token_index+1:]
-        return cls._find_in_tokens(tokens, flags)
+        return self._find_in_tokens(tokens, flags)


### PR DESCRIPTION
Pulls Elements and Tokens out into objects and passes them around while parsing to avoid the usage of singletons.

Implementation details:
- `parser_number.py`: functions that require access to elements and/or tokens are passed the arguments `elements` and `parsed_tokens` always with those names and always in that order.
- `parser_helper.py`: same as above.

Closes #11. See discussion there for the purpose of this PR.

Note: I'm getting 35/35 tests failed, but I was also getting that even before I made any changes. Please check locally.