### PR TITLE
Feat: add type-hinting for the public API

### DIFF
--- a/anitopy/anitopy.pyi
+++ b/anitopy/anitopy.pyi
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+from typing_extensions import TypedDict
+
+from anitopy.anitopy import default_options
+default_options: ParserOptions
+
+
+class ParserOptions(TypedDict, total=False):
+    allowed_delimiters: str
+    ignored_strings: List[str]
+    parse_episode_number: bool
+    parse_episode_title: bool
+    parse_file_extension: bool
+    parse_release_group: bool
+
+
+class ParserResult(TypedDict, total=False):
+    anime_title: str
+    anime_year: str
+    audio_term: str
+    episode_number: str
+    episode_title: str
+    file_checksum: str
+    file_extension: str
+    file_name: str
+    release_group: str
+    release_version: str
+    video_resolution: str
+    video_term: str
+
+
+def parse(filename: str, options: ParserOptions = default_options) -> Optional[ParserResult]: ...


### PR DESCRIPTION
This PR adds a [stub file](https://peps.python.org/pep-0484/#stub-files) `anitopy.pyi` to add backwards compatible type-hinting to the public `anitopy.parse` API.

@igorcmoura if you are interested in also type-hinting the internal methods, please do not merge this just yet. If you are interested, I'll add that into this PR as well.

https://user-images.githubusercontent.com/1884865/205460778-84134935-d86c-4777-82cb-488893b539d5.mp4

