### PR TITLE
Feat: support 4k resolution detection

### DIFF
--- a/anitopy/keyword.py
+++ b/anitopy/keyword.py
@@ -154,7 +154,7 @@ class KeywordManager:
         entries = [
             (ElementCategory.AUDIO_TERM, ['Dual Audio', 'Multi Audio']),
             (ElementCategory.VIDEO_TERM, ['H264', 'H.264', 'h264', 'h.264']),
-            (ElementCategory.VIDEO_RESOLUTION, ['480p', '720p', '1080p']),
+            (ElementCategory.VIDEO_RESOLUTION, ['480p', '720p', '1080p', '4k', '4K']),
             (ElementCategory.SUBTITLES, ['Multiple Subtitle', 'Multi Subs']),
             (ElementCategory.SOURCE, ['Blu-Ray'])
         ]

--- a/tests/fixtures/table.py
+++ b/tests/fixtures/table.py
@@ -2151,5 +2151,32 @@ table = [
             'video_resolution': '4K',
             'video_term': 'HEVC'
         }
+    ], [
+        '[SanKyuu][神墓][Shen Mu][Tomb of Fallen Gods][2022][12][4K HEVC AAC]',
+        None,
+        {
+            'anime_title': 'Shen Mu',
+            'anime_year': '2022',
+            'audio_term': 'AAC',
+            'episode_number': '12',
+            'file_name': '[SanKyuu][神墓][Shen Mu][Tomb of Fallen Gods][2022][12][4K HEVC AAC]',
+            'release_group': 'SanKyuu',
+            'video_resolution': '4K',
+            'video_term': 'HEVC'
+        }
+    ], [
+        '[Baws] Violet Evergarden: The Movie v2 (BD 4k HEVC TrueHD) [Dual-Audio]',
+        None,
+        {
+            'anime_title': 'Violet Evergarden: The Movie',
+            'anime_type': 'Movie',
+            'audio_term': 'Dual-Audio',
+            'file_name': '[Baws] Violet Evergarden: The Movie v2 (BD 4k HEVC TrueHD) [Dual-Audio]',
+            'release_group': 'Baws',
+            'release_version': '2',
+            'source': 'BD',
+            'video_resolution': '4k',
+            'video_term': 'HEVC'
+        }
     ]
 ]


### PR DESCRIPTION
Adds support for detecting `4k` and `4K` video resolutions.

I also added test cases for two inputs I found that were missing the `video_resolution` key in the result due to them being 4k. I noticed that this test case existed already in the tests table:

`[GM-Team][国漫][诛仙][Jade Dynasty][2022][11][HEVC][GB][4K]`

But when I parsed this input, the `video_resolution` key was missing despite the test case showing that it should be there.

```py
>>> import anitopy
>>> anitopy.parse("[GM-Team][国漫][诛仙][Jade Dynasty][2022][11][HEVC][GB][4K]")
{
    'file_name': '[GM-Team][国漫][诛仙][Jade Dynasty][2022][11][HEVC][GB][4K]',
    'video_term': 'HEVC',
    'anime_year': '2022',
    'episode_number': '11',
    'anime_title': 'Jade Dynasty',
    'release_group': 'GM-Team'
}
```