### PR TITLE
Fix: Episode number can be isolated at the end of the filename

### DIFF
--- a/anitopy/parser_helper.py
+++ b/anitopy/parser_helper.py
@@ -98,7 +98,7 @@ def is_token_isolated(parsed_tokens, token):
         return False
 
     next_token = parsed_tokens.find_next(token, TokenFlags.NOT_DELIMITER)
-    if next_token.category != TokenCategory.BRACKET:
+    if next_token is not None and next_token.category != TokenCategory.BRACKET:
         return False
 
     return True


### PR DESCRIPTION
Encountered this error when attempting to parse a filename that has an episode number isolated at the very end. Adds a None check, and can now confirm the parsing happens correctly.

Before fix:

```py
>>> import anitopy
>>> anitopy.parse("[M-L-Stuffs] Futari wa Precure (Pretty Cure) 01")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Tyler\Documents\GitHub\Tsundoku\.venv\lib\site-packages\anitopy\anitopy.py", line 48, in parse
    if not parser.parse():
  File "C:\Users\Tyler\Documents\GitHub\Tsundoku\.venv\lib\site-packages\anitopy\parser.py", line 18, in parse
    self.search_for_isolated_numbers()
  File "C:\Users\Tyler\Documents\GitHub\Tsundoku\.venv\lib\site-packages\anitopy\parser.py", line 92, in search_for_isolated_numbers
    not parser_helper.is_token_isolated(token):
  File "C:\Users\Tyler\Documents\GitHub\Tsundoku\.venv\lib\site-packages\anitopy\parser_helper.py", line 101, in is_token_isolated
    if next_token.category != TokenCategory.BRACKET:
AttributeError: 'NoneType' object has no attribute 'category'
```

After fix:

```py
>>> import anitopy
>>> anitopy.parse("[M-L-Stuffs] Futari wa Precure (Pretty Cure) 01")
{'file_name': '[M-L-Stuffs] Futari wa Precure (Pretty Cure) 01', 'episode_number': '01', 'anime_title': 'Futari wa Precure (Pretty Cure)', 'release_group': 'M-L-Stuffs'}
```